### PR TITLE
changes to help speed optimizations and profiling

### DIFF
--- a/simulations.py
+++ b/simulations.py
@@ -114,6 +114,7 @@ def get_mubar_sigmamu(Sigma_Ui, Ui, x1, Sigma11, Sigma12, Sigma21, Sigma22, mu1,
     sigma_new = Sigma_Ui
     return mu_new, Sigma_Ui, sigmabar, mubar
 
+
 def get_sigma_new_mu_new(x2, sigmabar, mu_new, sigma_new, mubar):
     for i in range(len(x2)):
         mu_new[x2[i]] = mubar[0,i]
@@ -140,22 +141,6 @@ def update_Ui(Cit, Ui, ce_Ui, Sigma_Ui, Nset):
     mu1 = np.array([ce_Ui[n] for n in x1], dtype=np.float64).reshape((1,len(x1)))
     mu2 = np.array([ce_Ui[n] for n in x2], dtype=np.float64).reshape((1,len(x2)))
     
-    #Sigma11 = np.ones((len(x1),len(x1)), dtype=np.float64)
-    #Sigma12 = np.ones((len(x1),len(x2)), dtype=np.float64)
-    #Sigma21 = np.ones((len(x2),len(x1)), dtype=np.float64)
-    #Sigma22 = np.ones((len(x2),len(x2)), dtype=np.float64)
-
-    #for j,i in np.ndindex(Sigma21.shape):
-    #    Sigma21[j,i] = Sigma_Ui[Cit[i], Nit[j]] 
-    #
-    #for i,j in np.ndindex(Sigma11.shape):
-    #    Sigma11[i,j] = Sigma_Ui[Cit[i],Cit[j]] 
-    #
-    #for j,i in np.ndindex(Sigma12.shape):
-    #    Sigma12[j,i] = Sigma_Ui[Nit[i],Cit[j]] 
-    #
-    #for i,j in np.ndindex(Sigma22.shape):
-    #    Sigma22[i,j] = Sigma_Ui[Nit[i], Nit[j]]
     Sigma11, Sigma12, Sigma21, Sigma22 = init_sigma(x1,x2, Sigma_Ui, Cit, Nit)
     
     #a = np.array([Ui[n] for n in x1]).reshape((1,len(x1)))

--- a/simulations.py
+++ b/simulations.py
@@ -84,6 +84,7 @@ def w_fun(CiT,Ui):
 def inv_nla_jit(A):
   return np.linalg.inv(A)
 
+@numba.jit(nopython=True)
 def init_sigma(x1,x2,Sigma_Ui, Cit, Nit):
     Sigma11 = np.ones((len(x1),len(x1)), dtype=np.float64)
     Sigma12 = np.ones((len(x1),len(x2)), dtype=np.float64)
@@ -114,11 +115,13 @@ def get_mubar_sigmamu(Sigma_Ui, Ui, x1, Sigma11, Sigma12, Sigma21, Sigma22, mu1,
     sigma_new = Sigma_Ui
     return mu_new, Sigma_Ui, sigmabar, mubar
 
-
+    
+@numba.jit(nopython=True)
 def get_sigma_new_mu_new(x2, sigmabar, mu_new, sigma_new, mubar):
-    for i in range(len(x2)):
+    len_x2 = len(x2)
+    for i in range(len_x2):
         mu_new[x2[i]] = mubar[0,i]
-        for j in range(len(x2)):
+        for j in range(len_x2):
             sigma_new[x2[i], x2[j]] = sigmabar[i, j]
     return mu_new, sigma_new
 

--- a/simulations.py
+++ b/simulations.py
@@ -336,6 +336,8 @@ if __name__ == '__main__':
     vals = [N_vals, T_vals, rho_vals, beta_vals, sigma_vals, alpha_vals, epsilon_vals]
     params = list(itertools.product(*vals))
 
+    print(len(params))
+
     parser = argparse.ArgumentParser()
     parser.add_argument('--no-joblib', dest='no_joblib', action='store_true',  help=' turn off joblib ')
     args = parser.parse_args()
@@ -381,7 +383,6 @@ if __name__ == '__main__':
                                                                         Sigma_V_ibar, 
                                                                         alpha, 
                                                                         epsilon, seed=i+1) for i in range(nr_pop))
-        break
         with open('data/sim_results.p', 'wb') as fp:
             pickle.dump(sim_results, fp)
     with open('data/sim_results.p', 'wb') as fp:

--- a/simulations.py
+++ b/simulations.py
@@ -107,17 +107,18 @@ def update_Ui(Cit, Ui, ce_Ui, Sigma_Ui, Nset):
     Sigma21 = np.ones((len(x2),len(x1)))
     Sigma22 = np.ones((len(x2),len(x2)))
 
-    for i in range(len(Cit)):
-        for j in range(len(Cit)):
-            Sigma11[i,j] = Sigma_Ui[Cit[i],Cit[j]] 
-        for j in range(len(Nit)):
-            Sigma21[j,i] = Sigma_Ui[Cit[i], Nit[j]] 
+    for j,i in np.ndindex(Sigma21.shape):
+        Sigma21[j,i] = Sigma_Ui[Cit[i], Nit[j]] 
+ 
+    for i,j in np.ndindex(Sigma11.shape):
+        Sigma11[i,j] = Sigma_Ui[Cit[i],Cit[j]] 
 
-    for i in range(len(Nit)):
-        for j in range(len(Cit)):
-            Sigma12[j,i] = Sigma_Ui[Nit[i],Cit[j]] 
-        for j in range(len(Nit)):
-            Sigma22[i,j] = Sigma_Ui[Nit[i], Nit[j]]
+    for j,i in np.ndindex(Sigma12.shape):
+        Sigma12[j,i] = Sigma_Ui[Nit[i],Cit[j]] 
+
+    for i,j in np.ndindex(Sigma22.shape):
+        Sigma22[i,j] = Sigma_Ui[Nit[i], Nit[j]]
+    
 
     a = np.array([Ui[n] for n in x1]).reshape((1,len(x1)))
     inv_mat = inv_nla_jit(Sigma11)


### PR DESCRIPTION
Pull Request to help try and speed up simulation runs:

- [X] Refactor code into seperate functions so that when we run `nohup time python3 -u -m cProfile -s tottime simulations.py` we can get a better breakdown on whats causing the bottlenecks
- [X] use argparse to add a `--no-joblib` flag to run a non parallel version to bench mark 1 simulation or 1 iteration. ( This was because when running cProfile with joblib a lot of valuable information was being swallowed by the parallelization)
- [X] Update distance from hop metric to euclidian ( not for speed but turns out we wanted euclidean metric instead)
- [X] remove unneeded color defn
- [X] numba decorators added where they showed performance improvements in test runs.